### PR TITLE
Example for using pulumi Update  Plan's

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Example  | Description |
 [Local Program](dotnet/LocalProgram) | This example shows how to use Automation API with an existing traditional CLI-driven Pulumi program. We add an Automation API deployment program to our existing CLI-driven S3 website program.
 [Cross-Language Program](dotnet/CrossLanguage) | This example shows how to use Automation API in `dotnet` with an existing traditional CLI-driven Pulumi program written in a __different__ language, in this case `go`. We add an Automation API deployment program to our Fargate program that deploys a web service via a Fargate task behind a load balancer.
 [Database Migration](dotnet/DatabaseMigration) | This example provisions an AWS Aurora SQL database and executes a database "migration" using the resulting connection info. This migration creates a table, inserts a few rows of data, and reads the data back to verify the setup. This is all done in a single program using an `inline` Pulumi program. With Automation API you can orchestrate complex workflows that go beyond infrastructure provisioning and into application management, database setup, etc.
+[Pulumi Plan with Preview Up](dotnet/PreviewUpProgram/) | This example shows how to use Pulumi plan option to preview changes and then apply that set of changes in two separate steps to allow validation of changes. https://www.pulumi.com/blog/announcing-public-preview-update-plans/
 
 ## Other projects using Automation API
 

--- a/dotnet/PreviewUpProgram/PreviewUpProgram.csproj
+++ b/dotnet/PreviewUpProgram/PreviewUpProgram.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <Nullable>enable</Nullable>
+    <RootNamespace></RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Pulumi.Automation" Version="3.*" />
+    <PackageReference Include="Pulumi.Random" Version="4.8.2" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet/PreviewUpProgram/PreviewUpProgram.sln
+++ b/dotnet/PreviewUpProgram/PreviewUpProgram.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30114.105
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PreviewUpProgram", "PreviewUpProgram.csproj", "{FFE3CEA2-69D8-4F31-985F-D6D3B6BAF85C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FFE3CEA2-69D8-4F31-985F-D6D3B6BAF85C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FFE3CEA2-69D8-4F31-985F-D6D3B6BAF85C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FFE3CEA2-69D8-4F31-985F-D6D3B6BAF85C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FFE3CEA2-69D8-4F31-985F-D6D3B6BAF85C}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/dotnet/PreviewUpProgram/Program.cs
+++ b/dotnet/PreviewUpProgram/Program.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Pulumi.Automation;
+using Pulumi.Random;
+
+class Program
+{
+    static async Task Main(string[] args)
+    {
+        // define our pulumi program "inline", other formats are supported see related other automation api examples
+        var program = PulumiFn.Create(() =>
+        {
+            var petName = new RandomPet("name", new RandomPetArgs { });
+
+            // export the random name
+            return new Dictionary<string, object?>
+            {
+                ["name"] = petName.Id.Apply(i => i),
+            };
+        });
+        var projectName = "inline_preview_up";
+        var stackName = "dev";
+
+        var destroy = args.Any() && args[0] == "destroy";
+        var preview = args.Any() && args[0] == "preview";
+        var up = args.Any() && args[0] == "up";
+
+        var executingAssemblyLocation = System.Reflection.Assembly.GetExecutingAssembly().Location;
+        var directory = Path.GetDirectoryName(executingAssemblyLocation);
+
+        var planPath = (preview || up) && args.Length > 1
+            ? args[1]
+            : Path.Join(directory, $"{stackName}.{projectName}.json");
+
+        // create or select a stack matching the specified name and project
+        // this will set up a workspace with everything necessary to run our inline program (program)
+        var stackArgs = new InlineProgramArgs(projectName, stackName, program);
+        var stack = await LocalWorkspace.CreateOrSelectStackAsync(stackArgs);
+
+        Console.WriteLine("successfully initialized stack");
+
+        // for inline programs, we must manage plugins ourselves
+        Console.WriteLine("installing plugins...");
+        await stack.Workspace.InstallPluginAsync("random", "v4.8.2");
+        Console.WriteLine("plugins installed");
+
+
+        Console.WriteLine("refreshing stack...");
+        await stack.RefreshAsync(new RefreshOptions { OnStandardOutput = Console.WriteLine });
+        Console.WriteLine("refresh complete");
+
+        if (destroy)
+        {
+            Console.WriteLine("destroying stack...");
+            await stack.DestroyAsync(new DestroyOptions { OnStandardOutput = Console.WriteLine });
+            Console.WriteLine("stack destroy complete");
+        }
+        else if (preview)
+        {
+            Console.WriteLine("previewing changes to stack...");
+
+            var result = await stack.PreviewAsync(new PreviewOptions {OnStandardOutput = Console.WriteLine,  Plan = planPath });
+            
+            Console.WriteLine("preview summary:");
+            foreach (var change in result.ChangeSummary)
+                Console.WriteLine($"    {change.Key}: {change.Value}");
+
+
+            Console.WriteLine($"stack preview saved to {planPath}");
+        }
+        else if (up)
+        {
+            Console.WriteLine($"updating stack from preview {planPath}...");
+            var result = await stack.UpAsync(new UpOptions { OnStandardOutput = Console.WriteLine, Plan = planPath });
+
+            if (result.Summary.ResourceChanges != null)
+            {
+                Console.WriteLine("update summary:");
+                foreach (var change in result.Summary.ResourceChanges)
+                    Console.WriteLine($"    {change.Key}: {change.Value}");
+            }
+
+            Console.WriteLine($"name: {result.Outputs["name"].Value}");
+        }
+        else
+        {
+            Console.WriteLine("no supported stack operations please provide preview, up or destroy as an argument");
+        }
+    }
+}

--- a/dotnet/PreviewUpProgram/README.md
+++ b/dotnet/PreviewUpProgram/README.md
@@ -1,0 +1,233 @@
+# Preview Up Program
+
+This program demonstrates how to use Automation API with Pulumi's Update plan accessed on CLI via `pulumi preview --save-plan <plan path>` then `pulumi up --plan <plan path>`
+
+To run this example you'll need a few pre-reqs:
+1. A Pulumi CLI installation ([v3.31.0](https://www.pulumi.com/docs/get-started/install/versions/) or later)
+2. The .NET SDK, this console application is targetting .NET Core 3.1.
+
+Running this program is just like any other .NET console application. You can run `dotnet run` from the project directory, or you could run the resulting `.exe` from the build directory in the `bin` folder. Arguments of `preview`, `up` or `destroy` are required  e.g. `donet run preview` with optional paths for the plan as a second argument.
+
+```shell
+C:\code\automation-api-examples\dotnet\PreviewUpProgram > dotnet run preview
+
+successfully initialized stack
+installing plugins...
+plugins installed
+refreshing stack...
+Refreshing (dev):
+
+
+Resources:
+
+Duration: 0s
+
+refresh complete
+previewing changes to stack...
+Previewing update (dev):
+
+ +  pulumi:pulumi:Stack inline_preview_up-dev create
+ +  random:index:RandomPet name create
+ +  pulumi:pulumi:Stack inline_preview_up-dev create
+
+Outputs:
+    name: output<string>
+
+Resources:
+    + 2 to create
+
+Update plan written to 'C:\code\automation-api-examples\dotnet\PreviewUpProgram\bin\Debug\netcoreapp3.1\dev.inline_preview_up.json'
+Run `pulumi up --plan='C:\code\automation-api-examples\dotnet\PreviewUpProgram\bin\Debug\netcoreapp3.1\dev.inline_preview_up.json'` to constrain the update to the operations planned by this preview
+preview summary:
+    Create: 2
+stack preview saved to C:\code\automation-api-examples\dotnet\PreviewUpProgram\bin\Debug\netcoreapp3.1\dev.inline_preview_up.json
+```
+
+Once the preview has been run you can then check the output of the planned changes. 
+
+
+```json
+{
+    "manifest": {
+        "time": "2022-08-26T12:47:47.1629119+10:00",
+        "magic": "0ed7606e6acb5b370078e9e1a4b22051c351075d7f4f5fa6ce66e0d04bfb5ec2",
+        "version": "v3.38.0"
+    },
+    "resourcePlans": {
+        "urn:pulumi:dev::inline_preview_up::pulumi:providers:random::default_4_8_2": {
+            "goal": {
+                "type": "pulumi:providers:random",
+                "name": "default_4_8_2",
+                "custom": true,
+                "checkedInputs": {
+                    "version": "4.8.2"
+                },
+                "inputDiff": {
+                    "adds": {
+                        "version": "4.8.2"
+                    }
+                },
+                "outputDiff": {},
+                "parent": "urn:pulumi:dev::inline_preview_up::pulumi:pulumi:Stack::inline_preview_up-dev",
+                "protect": false,
+                "customTimeouts": {}
+            },
+            "steps": [
+                "create"
+            ],
+            "state": {
+                "version": "4.8.2"
+            },
+            "seed": "9zw+7c8jAXsnAymhFtcYP5J8K45kY+zw1TnXxPzuQoY="
+        },
+        "urn:pulumi:dev::inline_preview_up::pulumi:pulumi:Stack::inline_preview_up-dev": {
+            "goal": {
+                "type": "pulumi:pulumi:Stack",
+                "name": "inline_preview_up-dev",
+                "custom": false,
+                "inputDiff": {},
+                "outputDiff": {
+                    "adds": {
+                        "name": "04da6b54-80e4-46f7-96ec-b56ff0331ba9"
+                    }
+                },
+                "protect": false,
+                "customTimeouts": {}
+            },
+            "steps": [
+                "create"
+            ],
+            "state": {
+                "name": "04da6b54-80e4-46f7-96ec-b56ff0331ba9"
+            },
+            "seed": "RX5t8kpVz0W8+TIv2koNV/YWZAgmg60zhYa/DNFJFG4="
+        },
+        "urn:pulumi:dev::inline_preview_up::random:index/randomPet:RandomPet::name": {
+            "goal": {
+                "type": "random:index/randomPet:RandomPet",
+                "name": "name",
+                "custom": true,
+                "checkedInputs": {
+                    "__defaults": [
+                        "length",
+                        "separator"
+                    ],
+                    "length": 2,
+                    "separator": "-"
+                },
+                "inputDiff": {
+                    "adds": {
+                        "__defaults": [
+                            "length",
+                            "separator"
+                        ],
+                        "length": 2,
+                        "separator": "-"
+                    }
+                },
+                "outputDiff": {},
+                "parent": "urn:pulumi:dev::inline_preview_up::pulumi:pulumi:Stack::inline_preview_up-dev",
+                "protect": false,
+                "provider": "urn:pulumi:dev::inline_preview_up::pulumi:providers:random::default_4_8_2::04da6b54-80e4-46f7-96ec-b56ff0331ba9",
+                "customTimeouts": {}
+            },
+            "steps": [
+                "create"
+            ],
+            "state": {
+                "id": "",
+                "length": 2,
+                "separator": "-"
+            },
+            "seed": "32uCFFfIEZ/NIlUgPv8LbYQq0Bq7kSlzMr6UqtYF2Dk="
+        }
+    }
+}
+
+```
+Then apply the changeset with up
+
+```shell
+C:\code\automation-api-examples\dotnet\PreviewUpProgram > dotnet run up C:\code\automation-api-examples\dotnet\PreviewUpProgram\bin\Debug\netcoreapp3.1\dev.inline_preview_up.json
+
+successfully initialized stack
+installing plugins...
+plugins installed
+refreshing stack...
+Refreshing (dev):
+
+
+Resources:
+
+Duration: 1s
+
+refresh complete
+updating stack from preview C:\code\automation-api-examples\dotnet\PreviewUpProgram\bin\Debug\netcoreapp3.1\dev.inline_preview_up.json...
+Updating (dev):
+
+ +  pulumi:pulumi:Stack inline_preview_up-dev creating
+ +  random:index:RandomPet name creating
+ +  random:index:RandomPet name created
+ +  pulumi:pulumi:Stack inline_preview_up-dev created
+
+Outputs:
+    name: "touched-walleye"
+
+Resources:
+    + 2 created
+
+Duration: 2s
+
+update summary:
+    Create: 2
+name: touched-walleye
+```
+
+
+
+To destroy our stack, we run our automation program with the `destroy` argument:
+
+```shell
+C:\code\automation-api-examples\dotnet\PreviewUpProgram > dotnet run destroy
+
+successfully initialized stack
+installing plugins...
+plugins installed
+refreshing stack...
+Refreshing (dev):
+
+ ~  pulumi:pulumi:Stack inline_preview_up-dev refreshing
+ ~  random:index:RandomPet name refreshing
+    pulumi:pulumi:Stack inline_preview_up-dev running
+    random:index:RandomPet name
+    pulumi:pulumi:Stack inline_preview_up-dev
+
+Outputs:
+    name: "touched-walleye"
+
+Resources:
+    2 unchanged
+
+Duration: 1s
+
+refresh complete
+destroying stack...
+Destroying (dev):
+
+ -  random:index:RandomPet name deleting
+ -  random:index:RandomPet name deleted
+ -  pulumi:pulumi:Stack inline_preview_up-dev deleting
+ -  pulumi:pulumi:Stack inline_preview_up-dev deleted
+
+Outputs:
+  - name: "touched-walleye"
+
+Resources:
+    - 2 deleted
+
+Duration: 1s
+
+The resources in the stack have been deleted, but the history and configuration associated with the stack are still maintained.
+If you want to remove the stack completely, run 'pulumi stack rm dev'.
+stack destroy complete
+```


### PR DESCRIPTION
Add an example for using Pulumi Update plans with the automation api.

Example shows how you can both save a plan as an argument to the preview command and also feed that plan to the up command to ensure an exact set of changes are applied. 

Support for this was added with https://github.com/pulumi/pulumi/releases/tag/v3.31.0 and into the pulumi cli with v3.24.1 https://www.pulumi.com/blog/announcing-public-preview-update-plans/