### PR TITLE
docs: fix occured typo in App.java error message

### DIFF
--- a/java/localProgram/automation/src/main/java/com/pulumi/App.java
+++ b/java/localProgram/automation/src/main/java/com/pulumi/App.java
@@ -42,7 +42,7 @@ public class App {
             }
         } catch (Exception ex) {
             // Print the exception message
-            System.err.println("An exception occured while running the inline Pulumi program: " + ex.getMessage());
+            System.err.println("An exception occurred while running the inline Pulumi program: " + ex.getMessage());
 
             System.err.print("Stack trace: ");
             ex.printStackTrace();


### PR DESCRIPTION
Fix "occured" -> "occurred" in the error message printed when the inline Pulumi program throws.